### PR TITLE
Available from official webstores now

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ The rules whose *URL Pattern* match with the page address will be selected and q
 
 ## Installation
 
+> For the impatients: [Firefox add-on](https://addons.mozilla.org/en-US/firefox/addon/codeinjector/), [Chrome extension](https://chrome.google.com/webstore/detail/code-injector/jgcallaoodbhagkaoobenaabockcejmc)
+
 - download the repository,
 - (optional) to apply changes to the *src* and rebuild:
   - launch `npm install` to download the dev-dependencies,


### PR DESCRIPTION
Insert links to Firefox add-on and Chrome extension. Addresses #6 (chrome web store).